### PR TITLE
feat(payments) INT-858 Add Google Pay button to Checkot Button Strategy

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -1,6 +1,6 @@
 import { RequestOptions } from '../common/http-request';
 
-import { BraintreePaypalButtonInitializeOptions, CheckoutButtonMethodType, GooglePayBraintreeButtonInitializeOptions } from './strategies';
+import { BraintreePaypalButtonInitializeOptions, CheckoutButtonMethodType, GooglePayButtonInitializeOptions } from './strategies';
 
 /**
  * The set of options for configuring the checkout button.
@@ -34,5 +34,11 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * The options that are required to facilitate Braintree GooglePay. They can be
      * omitted unles you need to support Braintree GooglePay.
      */
-    googlepaybraintree?: GooglePayBraintreeButtonInitializeOptions;
+    googlepaybraintree?: GooglePayButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate Stripe GooglePay. They can be
+     * omitted unles you need to support Stripe GooglePay.
+     */
+    googlepaystripe?: GooglePayButtonInitializeOptions;
 }

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -7,7 +7,7 @@ import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
 
-import { createGooglePayBraintreePaymentProcessor } from '../payment/strategies/googlepay';
+import { createGooglePayBraintreePaymentProcessor, createGooglePayStripePaymentProcessor } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 
@@ -15,7 +15,7 @@ import {
     BraintreePaypalButtonStrategy,
     CheckoutButtonMethodType,
     CheckoutButtonStrategy,
-    GooglePayBraintreeButtonStrategy,
+    GooglePayButtonStrategy,
     MasterpassButtonStrategy
 } from './strategies';
 
@@ -60,11 +60,20 @@ export default function createCheckoutButtonRegistry(
         ));
 
     registry.register(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE, () =>
-        new GooglePayBraintreeButtonStrategy(
+        new GooglePayButtonStrategy(
             store,
             formPoster,
             checkoutActionCreator,
             createGooglePayBraintreePaymentProcessor(store)
+        )
+    );
+
+    registry.register(CheckoutButtonMethodType.GOOGLEPAY_STRIPE, () =>
+        new GooglePayButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            createGooglePayStripePaymentProcessor(store)
         )
     );
 

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -2,6 +2,7 @@ export enum CheckoutButtonMethodType {
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',
     GOOGLEPAY_BRAINTREE = 'googlepaybraintree',
+    GOOGLEPAY_STRIPE= 'googlepaystripe',
     MASTERPASS = 'masterpass',
 
 }

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-options.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-options.ts
@@ -1,0 +1,18 @@
+import { ButtonColor, ButtonType } from '../../../payment/strategies/googlepay/googlepay';
+
+export interface GooglePayButtonInitializeOptions {
+    /**
+     * The color of the GooglePay button that will be inserted.
+     *  black (default): a black button suitable for use on white or light backgrounds.
+     *  white: a white button suitable for use on colorful backgrounds.
+     */
+    buttonColor?: ButtonColor;
+
+    /**
+     * The size of the GooglePay button that will be inserted.
+     *  long: "Buy with Google Pay" button (default). A translated button label may appear
+     *         if a language specified in the viewer's browser matches an available language.
+     *  short: Google Pay payment button without the "Buy with" text.
+     */
+    buttonType?: ButtonType;
+}

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -7,7 +7,7 @@ import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
-export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStrategy {
+export default class GooglePayButtonStrategy extends CheckoutButtonStrategy {
     private _methodId?: string;
     private _walletButton?: HTMLElement;
 
@@ -83,7 +83,7 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
 
         return this._googlePayPaymentProcessor.displayWallet()
             .then(paymentData => this._googlePayPaymentProcessor.handleSuccess(paymentData)
-            .then(() => this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress)))
+                .then(() => this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress)))
             .then(() => this._onPaymentSelectComplete())
             .catch(error => this._onError(error));
     }

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -1,0 +1,52 @@
+
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import { CheckoutButtonMethodType } from '../checkout-button-method-type';
+import { PaymentMethod } from '../../../payment';
+import { getGooglePay } from '../../../payment/payment-methods.mock';
+import { ButtonColor, ButtonType } from '../../../payment/strategies/googlepay/googlepay';
+
+
+export function getPaymentMethod(): PaymentMethod {
+    return {
+        ...getGooglePay(),
+        initializationData: {
+            checkoutId: 'checkoutId',
+            allowedCardTypes: ['visa', 'amex', 'mastercard'],
+        },
+    };
+}
+
+export enum Mode {
+    Full,
+    UndefinedContainer,
+    InvalidContainer,
+    GooglePayBraintree,
+    GooglePayStripe,
+}
+
+export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButtonInitializeOptions {
+    const methodId = { methodId: CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE };
+    const containerId = 'googlePayCheckoutButton';
+    const undefinedContainerId = { containerId: '' };
+    const invalidContainerId = { containerId: 'invalid_container' };
+    const googlepaybraintree = { googlepaybraintree: { buttonType: ButtonType.Short } };
+    const googlepaystripe = { googlepaystripe: { buttonType: ButtonType.Short } };
+
+    switch (mode) {
+        case Mode.UndefinedContainer: {
+            return { ...methodId, ...undefinedContainerId };
+        }
+        case Mode.InvalidContainer: {
+            return { ...methodId, ...invalidContainerId };
+        }
+        case Mode.GooglePayBraintree: {
+            return { ...methodId, containerId, ...googlepaybraintree };
+        }
+        case Mode.GooglePayStripe: {
+            return { ...methodId, containerId, ...googlepaystripe };
+        }
+        default: {
+            return { ...methodId, containerId };
+        }
+    }
+}

--- a/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
@@ -11,9 +11,9 @@ import { getCustomerState } from '../../../customer/customers.mock';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import {
-    createGooglePayBraintreePaymentProcessor,
+    createGooglePayStripePaymentProcessor,
     GooglePaymentData,
-    GooglePayPaymentProcessor
+    GooglePayPaymentProcessor 
 } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
@@ -21,7 +21,7 @@ import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import GooglePayButtonStrategy from './googlepay-button-strategy';
 import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-button.mock';
 
-describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
+describe('GooglePayStripeCheckoutButtonStrategy', () => {
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let checkoutButtonOptions: CheckoutButtonInitializeOptions;
@@ -51,7 +51,7 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
             new ConfigActionCreator(new ConfigRequestSender(requestSender))
         );
 
-        paymentProcessor = createGooglePayBraintreePaymentProcessor(store);
+        paymentProcessor = createGooglePayStripePaymentProcessor(store);
 
         formPoster = createFormPoster();
 
@@ -92,7 +92,7 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
         document.body.removeChild(container);
     });
 
-    it('creates an instance of GooglePayBraintreeButtonStrategy', () => {
+    it('creates an instance of GooglePayStripeButtonStrategy', () => {
         expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
     });
 
@@ -148,7 +148,7 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
         let checkoutButtonOptions: CheckoutButtonInitializeOptions;
 
         beforeEach(() => {
-            checkoutButtonOptions = getCheckoutButtonOptions();
+            checkoutButtonOptions = getCheckoutButtonOptions(Mode.GooglePayStripe);
         });
 
         it('check if googlepay payment processor deinitialize is called', async () => {

--- a/src/checkout-buttons/strategies/googlepay/index.ts
+++ b/src/checkout-buttons/strategies/googlepay/index.ts
@@ -1,0 +1,3 @@
+export { default as GooglePayButtonStrategy } from './googlepay-button-strategy';
+
+export { GooglePayButtonInitializeOptions } from './googlepay-button-options';

--- a/src/checkout-buttons/strategies/index.ts
+++ b/src/checkout-buttons/strategies/index.ts
@@ -1,8 +1,8 @@
 export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
-export { default as GooglePayBraintreeButtonStrategy } from './googlepay/googlepay-braintree-button-strategy';
+export { GooglePayButtonStrategy } from './googlepay';
 export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
 export { default as MasterpassButtonStrategy } from './masterpass-button-strategy';
 export { CheckoutButtonMethodType } from './checkout-button-method-type';
 
 export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
-export { GooglePayBraintreeButtonInitializeOptions } from './googlepay/googlepay-braintree-button-options';
+export { GooglePayButtonInitializeOptions } from './googlepay';


### PR DESCRIPTION
## What? [INT-858](https://jira.bigcommerce.com/browse/INT-858)
As a shopper
I want to use Google Pay from the Quick Cart page through Stripe.
So that I can pay using my favorite wallet.

## Why?
We need to display the checkout button on the cart page and the quick cart using the checkout button strategy.

## Testing / Proof
![image](https://user-images.githubusercontent.com/1013633/47821682-20e2d600-dd27-11e8-9410-5b0273b56611.png)

@clopezh @vmparra
